### PR TITLE
Fixed links typos

### DIFF
--- a/src/_posts/action_mailbox.md
+++ b/src/_posts/action_mailbox.md
@@ -626,7 +626,7 @@ the Rails Guides.
 
 Postmark is my preferred email service provider from the default options Action
 Mailbox provides. I have another articles with the detail for [deploying to
-Postmark](/deploy_action_mailbox_with_postmark).
+Postmark](/ruby/deploy_action_mailbox_with_postmark).
 
 **Active Storage Service**
 

--- a/src/_posts/deploy_action_mailbox_with_postmark.md
+++ b/src/_posts/deploy_action_mailbox_with_postmark.md
@@ -8,7 +8,7 @@ with Postmark."
 author: cody
 ---
 
-In my recent [Action Mailbox Post](/action_mailbox), I reviewed a ton of
+In my recent [Action Mailbox Post](/ruby/action_mailbox), I reviewed a ton of
 information on how Action Mailbox works and how you can use it.  One very
 important topic I didn't go over was how to deploy your Action Mailbox code to
 one of the default providers from Rails.


### PR DESCRIPTION
Mising /ruby/ at the begining of the post links